### PR TITLE
Update the HELICS GitHub repo url

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # HELICS.jl
 
-[![Travis Build Status](https://img.shields.io/travis/com/GMLC-TDC/HELICS.jl/master.svg)](https://travis-ci.com/GMLC-TDC/HELICS.jl) [![Appveyor Build Status](https://img.shields.io/appveyor/ci/kdheepak/helics-jl.svg)](https://ci.appveyor.com/project/kdheepak/helics-jl) [![Docs](https://img.shields.io/badge/docs-latest-blue.svg)](https://gmlc-tdc.github.io/HELICS.jl/latest) [![Codecov](https://img.shields.io/codecov/c/github/gmlc-tdc/HELICS.jl.svg)](https://codecov.io/gh/GMLC-TDC/HELICS.jl) [![Gitter](https://img.shields.io/gitter/room/GMLC-TDC/HELICS-src.svg)](https://gitter.im/GMLC-TDC/HELICS-src) [![Releases](https://img.shields.io/github/tag-date/GMLC-TDC/HELICS.jl.svg)](https://github.com/GMLC-TDC/HELICS.jl/releases)
+[![Travis Build Status](https://img.shields.io/travis/com/GMLC-TDC/HELICS.jl/master.svg)](https://travis-ci.com/GMLC-TDC/HELICS.jl) [![Appveyor Build Status](https://img.shields.io/appveyor/ci/kdheepak/helics-jl.svg)](https://ci.appveyor.com/project/kdheepak/helics-jl) [![Docs](https://img.shields.io/badge/docs-latest-blue.svg)](https://gmlc-tdc.github.io/HELICS.jl/latest) [![Codecov](https://img.shields.io/codecov/c/github/gmlc-tdc/HELICS.jl.svg)](https://codecov.io/gh/GMLC-TDC/HELICS.jl) [![Gitter](https://img.shields.io/gitter/room/GMLC-TDC/HELICS.svg)](https://gitter.im/GMLC-TDC/HELICS) [![Releases](https://img.shields.io/github/tag-date/GMLC-TDC/HELICS.jl.svg)](https://github.com/GMLC-TDC/HELICS.jl/releases)
 
-[HELICS.jl](https://github.com/GMLC-TDC/HELICS.jl) is a cross-platform Julia wrapper around the [HELICS](https://github.com/GMLC-TDC/HELICS-src) library.
+[HELICS.jl](https://github.com/GMLC-TDC/HELICS.jl) is a cross-platform Julia wrapper around the [HELICS](https://github.com/GMLC-TDC/HELICS) library.
 
 **This package is now available for Windows, Mac, and Linux.**
 


### PR DESCRIPTION
Update the HELICS GitHub url after the June 19, 2019 rename from HELICS-src.