### PR TITLE
Fix helicsInputGetComplexVector

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -2,6 +2,7 @@
 
 [[ArgTools]]
 uuid = "0dad84c5-d112-42e6-8d28-ef12dabb789f"
+version = "1.1.1"
 
 [[Artifacts]]
 uuid = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
@@ -19,38 +20,44 @@ deps = ["Printf"]
 uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
 
 [[DocStringExtensions]]
-deps = ["LibGit2", "Markdown", "Pkg", "Test"]
-git-tree-sha1 = "9d4f64f79012636741cf01133158a54b24924c32"
+deps = ["LibGit2"]
+git-tree-sha1 = "b19534d1895d702889b219c382a6e18010797f0b"
 uuid = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
-version = "0.8.4"
+version = "0.8.6"
 
 [[Downloads]]
-deps = ["ArgTools", "LibCURL", "NetworkOptions"]
+deps = ["ArgTools", "FileWatching", "LibCURL", "NetworkOptions"]
 uuid = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
+version = "1.6.0"
+
+[[FileWatching]]
+uuid = "7b1f6079-737a-58dc-b8bc-7a2ca5c1b5ee"
 
 [[HELICS_jll]]
-deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg", "ZeroMQ_jll"]
-git-tree-sha1 = "64f404a44586f5450527dc707338a447ef18e4a4"
+deps = ["Artifacts", "JLLWrappers", "Libdl", "ZeroMQ_jll"]
+git-tree-sha1 = "ee95326d9dbab2d3e58293bfcc7a41b01390e394"
 uuid = "ef3b0bb0-9dc6-5204-90f3-946fd7d0da3e"
-version = "2.7.0+0"
+version = "3.5.2+0"
 
 [[InteractiveUtils]]
 deps = ["Markdown"]
 uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 
 [[JLLWrappers]]
-deps = ["Preferences"]
-git-tree-sha1 = "642a199af8b68253517b80bd3bfd17eb4e84df6e"
+deps = ["Artifacts", "Preferences"]
+git-tree-sha1 = "7e5d6779a1e09a36db2a7b6cff50942a0a7d0fca"
 uuid = "692b3bcd-3c85-4b1f-b108-f13ce0eb3210"
-version = "1.3.0"
+version = "1.5.0"
 
 [[LibCURL]]
 deps = ["LibCURL_jll", "MozillaCACerts_jll"]
 uuid = "b27032c2-a3e7-50c8-80cd-2d36dbcbfd21"
+version = "0.6.3"
 
 [[LibCURL_jll]]
 deps = ["Artifacts", "LibSSH2_jll", "Libdl", "MbedTLS_jll", "Zlib_jll", "nghttp2_jll"]
 uuid = "deac9b47-8bc7-5906-a0fe-35ac56dc84c0"
+version = "7.84.0+0"
 
 [[LibGit2]]
 deps = ["Base64", "NetworkOptions", "Printf", "SHA"]
@@ -59,6 +66,7 @@ uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
 [[LibSSH2_jll]]
 deps = ["Artifacts", "Libdl", "MbedTLS_jll"]
 uuid = "29816b5a-b9ab-546f-933c-edad1886dfa8"
+version = "1.10.2+0"
 
 [[Libdl]]
 uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
@@ -73,22 +81,26 @@ uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
 [[MbedTLS_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "c8ffd9c3-330d-5841-b78e-0817d7145fa1"
+version = "2.28.2+0"
 
 [[MozillaCACerts_jll]]
 uuid = "14a3606d-f60d-562e-9121-12d972cd8159"
+version = "2022.10.11"
 
 [[NetworkOptions]]
 uuid = "ca575930-c2e3-43a9-ace4-1e988b2c1908"
+version = "1.2.0"
 
 [[Pkg]]
-deps = ["Artifacts", "Dates", "Downloads", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "Serialization", "TOML", "Tar", "UUIDs", "p7zip_jll"]
+deps = ["Artifacts", "Dates", "Downloads", "FileWatching", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "Serialization", "TOML", "Tar", "UUIDs", "p7zip_jll"]
 uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+version = "1.9.0"
 
 [[Preferences]]
 deps = ["TOML"]
-git-tree-sha1 = "00cfd92944ca9c760982747e9a1d0d5d86ab1e5a"
+git-tree-sha1 = "9306f6085165d270f7e3db02af26a400d580f5c6"
 uuid = "21216c6a-2e73-6563-6e65-726566657250"
-version = "1.2.2"
+version = "1.4.3"
 
 [[Printf]]
 deps = ["Unicode"]
@@ -99,11 +111,12 @@ deps = ["InteractiveUtils", "Markdown", "Sockets", "Unicode"]
 uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 
 [[Random]]
-deps = ["Serialization"]
+deps = ["SHA", "Serialization"]
 uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
 [[SHA]]
 uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
+version = "0.7.0"
 
 [[Serialization]]
 uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
@@ -114,14 +127,12 @@ uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
 [[TOML]]
 deps = ["Dates"]
 uuid = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
+version = "1.0.3"
 
 [[Tar]]
 deps = ["ArgTools", "SHA"]
 uuid = "a4e569a6-e804-4fa4-b0f3-eef7a1d5b13e"
-
-[[Test]]
-deps = ["InteractiveUtils", "Logging", "Random", "Serialization"]
-uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+version = "1.10.0"
 
 [[UUIDs]]
 deps = ["Random", "SHA"]
@@ -131,14 +142,15 @@ uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
 
 [[ZeroMQ_jll]]
-deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg", "libsodium_jll"]
-git-tree-sha1 = "74a74a3896b63980734cc876da8a103454559fe8"
+deps = ["Artifacts", "JLLWrappers", "Libdl", "libsodium_jll"]
+git-tree-sha1 = "42f97fb27394378591666ab0e9cee369e6d0e1f9"
 uuid = "8f1865be-045e-5c20-9c9f-bfbfb0764568"
-version = "4.3.2+6"
+version = "4.3.5+0"
 
 [[Zlib_jll]]
 deps = ["Libdl"]
 uuid = "83775a58-1f1d-513f-b197-d71354ab007a"
+version = "1.2.13+0"
 
 [[libsodium_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
@@ -149,7 +161,9 @@ version = "1.0.20+0"
 [[nghttp2_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "8e850ede-7688-5339-a07c-302acd2aaf8d"
+version = "1.48.0+0"
 
 [[p7zip_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "3f19e933-33d8-53b3-aaab-bd5110c3b7a0"
+version = "17.4.0+0"

--- a/src/api.jl
+++ b/src/api.jl
@@ -52,9 +52,9 @@ Wrap data in [`DataBuffer`](@ref)
 - [`DataBuffer`](@ref)
 """
 function helicsWrapDataInBuffer(data::String)::DataBuffer
-	dataSize = length(data)
-	dataCapacity = dataSize + 1
-	dataPtr = pointer(data)
+    dataSize = length(data)
+    dataCapacity = dataSize + 1
+    dataPtr = pointer(data)
     return Lib.helicsWrapDataInBuffer(data, dataSize, dataCapacity)
 end
 
@@ -81,7 +81,7 @@ Get size of a[`DataBuffer`](@ref)
 - Int32
 """
 function helicsDataBufferSize(data::DataBuffer)::Int32
-	return Lib.helicsDataBufferSize(data)
+    return Lib.helicsDataBufferSize(data)
 end
 
 """
@@ -96,7 +96,7 @@ Get capacity of a[`DataBuffer`](@ref)
 - Int32
 """
 function helicsDataBufferCapacity(data::DataBuffer)::Int32
-	return Lib.helicsDataBufferCapacity(data)
+    return Lib.helicsDataBufferCapacity(data)
 end
 
 """
@@ -111,7 +111,7 @@ Get a pointer to the raw data in a [`DataBuffer`](@ref)
 - Ptr{Cvoid} 
 """
 function helicsDataBufferData(data::DataBuffer)::Ptr{Cvoid}
-	return Lib.helicsDataBufferData(data)
+    return Lib.helicsDataBufferData(data)
 end
 
 """
@@ -127,7 +127,7 @@ Increase [`DataBuffer`](@ref) capacity without reallocating memory
 - true is successful else false
 """
 function helicsDataBufferReserve(data::DataBuffer, newCapacity::Int32)::Bool
-	return Lib.helicsDataBufferReserve(data) == 1 ? true : false
+    return Lib.helicsDataBufferReserve(data) == 1 ? true : false
 end
 
 """
@@ -142,7 +142,7 @@ copy and existing DataBuffer to and new one
 - [`DataBuffer`](@ref)
 """
 function helicsDataBufferClone(data::DataBuffer)::DataBuffer
-	return Lib.helicsDataBufferClone(data)
+    return Lib.helicsDataBufferClone(data)
 end
 
 """
@@ -158,7 +158,7 @@ convert an integer to serialized bytes
 - Int32 Bytes serialized.
 """
 function helicsIntegerToBytes(value::Int64, data::DataBuffer)::Int32
-	return Lib.helicsIntegerToBytes(value, data)
+    return Lib.helicsIntegerToBytes(value, data)
 end
 
 """
@@ -174,7 +174,7 @@ convert a double to serialized bytes
 - Int32 Bytes serialized.
 """
 function helicsDoubleToBytes(value::Float64, data::DataBuffer)::Int32
-	return Lib.helicsDoubleToBytes(value, data)
+    return Lib.helicsDoubleToBytes(value, data)
 end
 
 """
@@ -190,7 +190,7 @@ convert a string to serialized bytes
 - Int32 Bytes serialized.
 """
 function helicsStringToBytes(value::String, data::DataBuffer)::Int32
-	return Lib.helicsStringToBytes(value, data)
+    return Lib.helicsStringToBytes(value, data)
 end
 
 """
@@ -206,7 +206,7 @@ convert a raw string to serialized bytes
 - Int32 Bytes serialized.
 """
 function helicsRawStringToBytes(value::String, data::DataBuffer)::Int32
-	return Lib.helicsRawStringToBytes(value, data)
+    return Lib.helicsRawStringToBytes(value, data)
 end
 
 """
@@ -222,7 +222,7 @@ convert a boolean to serialized bytes
 - Int32 Bytes serialized.
 """
 function helicsBooleanToBytes(value::Bool, data::DataBuffer)::Int32
-	return Lib.helicsBooleanToBytes(value ? 1 : 0, data)
+    return Lib.helicsBooleanToBytes(value ? 1 : 0, data)
 end
 
 """
@@ -238,7 +238,7 @@ convert a char to serialized bytes
 - Int32 Bytes serialized.
 """
 function helicsCharToBytes(value::Char, data::DataBuffer)::Int32
-	return Lib.helicsCharToBytes(value, data)
+    return Lib.helicsCharToBytes(value, data)
 end
 
 """
@@ -254,7 +254,7 @@ convert a HelicsTime to serialized bytes
 - Int32 Bytes serialized.
 """
 function helicsTimeToBytes(value::HELICS.HELICS_TIME, data::DataBuffer)::Int32
-	return Lib.helicsTimeToBytes(value, data)
+    return Lib.helicsTimeToBytes(value, data)
 end
 
 """
@@ -270,7 +270,7 @@ convert a complex to serialized bytes
 - Int32 Bytes serialized.
 """
 function helicsComplexToBytes(value::ComplexF64, data::DataBuffer)::Int32
-	return Lib.helicsComplexToBytes(value.re, value.im, data)
+    return Lib.helicsComplexToBytes(value.re, value.im, data)
 end
 
 """
@@ -286,8 +286,8 @@ convert a vector of doubles to serialized bytes
 - Int32 Bytes serialized.
 """
 function helicsVectorToBytes(value::Vector{Float64}, data::DataBuffer)::Int32
-	dataSize = length(value)
-	return Lib.helicsVectorToBytes(value, dataSize, data)
+    dataSize = length(value)
+    return Lib.helicsVectorToBytes(value, dataSize, data)
 end
 
 """
@@ -304,7 +304,7 @@ convert a named point to serialized bytes
 - Int32 Bytes serialized.
 """
 function helicsNamedPointToBytes(name::String, value::Int64, data::DataBuffer)::Int32
-	return Lib.helicsVectorToBytes(name, value, data)
+    return Lib.helicsVectorToBytes(name, value, data)
 end
 
 """
@@ -320,14 +320,14 @@ convert a vector of complex values to serialized bytes
 - Int32 Bytes serialized.
 """
 function helicsComplexVectorToBytes(value::Vector{ComplexF64}, data::DataBuffer)::Int32
-	complexDataSize = length(value)
-	doubleValue = Vector{Float64}(undef, 0)
-	for v in value
-		push!(doubleValue, v.re)
-		push!(doubleValue, v.im)
-	end
-	dataSize = length(doubleValue)
-	return Lib.helicsComplexVectorToBytes(doubleValue, dataSize, data)
+    complexDataSize = length(value)
+    doubleValue = Vector{Float64}(undef, 0)
+    for v in value
+        push!(doubleValue, v.re)
+        push!(doubleValue, v.im)
+    end
+    dataSize = length(doubleValue)
+    return Lib.helicsComplexVectorToBytes(doubleValue, dataSize, data)
 end
 
 """
@@ -342,7 +342,7 @@ return the an integer value of the data type of a DataBuffer.
 - Int data type integer value.
 """
 function helicsDataBufferType(data::DataBuffer)::Int
-	return Lib.helicsDataBufferType(data)
+    return Lib.helicsDataBufferType(data)
 end
 
 """
@@ -357,7 +357,7 @@ Get data from DataBuffer as an integer.
 - Int64
 """
 function helicsDataBufferToInteger(data::DataBuffer)::Int64
-	return Lib.helicsDataBufferToInteger(data)
+    return Lib.helicsDataBufferToInteger(data)
 end
 
 """
@@ -372,7 +372,7 @@ Get data from DataBuffer as a double.
 - Float64
 """
 function helicsDataBufferToDouble(data::DataBuffer)::Float64
-	return Lib.helicsDataBufferToDouble(data)
+    return Lib.helicsDataBufferToDouble(data)
 end
 
 """
@@ -387,7 +387,7 @@ Get data from DataBuffer as a boolean.
 - Bool
 """
 function helicsDataBufferToBoolean(data::DataBuffer)::Bool
-	return Lib.helicsDataBufferToBoolean(data) == 1 ? true : false
+    return Lib.helicsDataBufferToBoolean(data) == 1 ? true : false
 end
 
 """
@@ -402,7 +402,7 @@ Get data from DataBuffer as a single char.
 - Char
 """
 function helicsDataBufferToChar(data::DataBuffer)::Char
-	return Lib.helicsDataBufferToChar(data)
+    return Lib.helicsDataBufferToChar(data)
 end
 
 """
@@ -417,7 +417,7 @@ Get size of string data size from DataBuffer.
 - Int
 """
 function helicsDataBufferStringSize(data::DataBuffer)::Int
-	return Lib.helicsDataBufferStringSize(data)
+    return Lib.helicsDataBufferStringSize(data)
 end
 
 """
@@ -432,11 +432,11 @@ Get string data from DataBuffer.
 - String
 """
 function helicsDataBufferToString(data::DataBuffer)::String
-	maxStringLen = DataBufferStringSize(data)
+    maxStringLen = DataBufferStringSize(data)
     outputString = repeat(" ", maxStringLen + 2)
     actualLength = Ref{Int32}(maxStringLen)
-	Lib.helicsDataBufferToString(data, outputString, maxStringLen, actualLength)
-	return outputString[1:actualLength[]-1]
+    Lib.helicsDataBufferToString(data, outputString, maxStringLen, actualLength)
+    return outputString[1:actualLength[]-1]
 end
 
 """
@@ -451,11 +451,11 @@ Get raw string data from DataBuffer.
 - String
 """
 function helicsDataBufferToRawString(data::DataBuffer)::String
-	maxStringLen = DataBufferStringSize(data)
+    maxStringLen = DataBufferStringSize(data)
     outputString = repeat(" ", maxStringLen)
     actualLength = Ref{Int32}(maxStringLen)
-	Lib.helicsDataBufferToRawString(data, outputString, maxStringLen, actualLength)
-	return outputString[1:actualLength[]]
+    Lib.helicsDataBufferToRawString(data, outputString, maxStringLen, actualLength)
+    return outputString[1:actualLength[]]
 end
 
 """
@@ -470,7 +470,7 @@ Get data from DataBuffer as a HELICS.HelicsTime.
 - Float64
 """
 function helicsDataBufferToTime(data::DataBuffer)::Float64
-	return Lib.helicsDataBufferToTime(data)
+    return Lib.helicsDataBufferToTime(data)
 end
 
 """
@@ -485,7 +485,7 @@ Get data from DataBuffer as a complex.
 - ComplexF64
 """
 function helicsDataBufferToComplex(data::DataBuffer)::ComplexF64
-	real = Ref{Float64}(0)
+    real = Ref{Float64}(0)
     imag = Ref{Float64}(0)
     Lib.helicsDataBufferToComplex(data, real, imag)
     return real[] + im * imag[]
@@ -519,7 +519,7 @@ Get size of vector data size from DataBuffer.
 - Int
 """
 function helicsDataBufferVectorSize(data::DataBuffer)::Int
-	return Lib.helicsDataBufferVectorSize(data)
+    return Lib.helicsDataBufferVectorSize(data)
 end
 
 """
@@ -534,9 +534,9 @@ Get vector of doubles from DataBuffer.
 - Vector{Float64}
 """
 function helicsDataBufferToVector(data::DataBuffer)::Vector{Float64}
-	maxlen = Cint(DataBufferVectorSize(data))
-	values = Vector{Float64}(undef, maxlen)
-	actualSize = Ref(maxlen)
+    maxlen = Cint(DataBufferVectorSize(data))
+    values = Vector{Float64}(undef, maxlen)
+    actualSize = Ref(maxlen)
     Lib.helicsDataBufferToVector(data, values, maxlen, actualSize)
     return values[1:actualSize[]]
 end
@@ -553,14 +553,14 @@ Get vector of complex values from DataBuffer.
 - Vector{ComplexF64}
 """
 function helicsDataBufferToComplexVector(data::DataBuffer)::Vector{ComplexF64}
-	maxlen = Cint(DataBufferVectorSize(data))
-	doubleValues = Vector{Float64}(undef, maxlen)
-	actualSize = Ref(maxlen)
+    maxlen = Cint(DataBufferVectorSize(data))
+    doubleValues = Vector{Float64}(undef, maxlen)
+    actualSize = Ref(maxlen)
     Lib.helicsDataBufferToComplexVector(data, doubleValues, maxlen, actualSize)
-	complexValues = Vector{ComplexF64}(undef, 0)
-	for i = 1:actualSize[]/2
-		push!(complexValues, doubleValues[2*i-1] + im * doubleValues[2*i])
-	end
+    complexValues = Vector{ComplexF64}(undef, 0)
+    for i = 1:actualSize[]/2
+        push!(complexValues, doubleValues[2*i-1] + im * doubleValues[2*i])
+    end
     return complexValues
 end
 
@@ -575,11 +575,11 @@ Get a named point from DataBuffer.
 
 - Tuple{String, Float64}
 """
-function helicsDataBufferToNamedPoint(data::DataBuffer)::Tuple{String, Float64}
-	maxStringLength = DataBufferStringSize(data)
-	outputString = repeat(" ", maxStringLength + 2)
-	actualLength = Ref{Int32}(maxStringLength)
-	val = Ref{Float64}(0.0)
+function helicsDataBufferToNamedPoint(data::DataBuffer)::Tuple{String,Float64}
+    maxStringLength = DataBufferStringSize(data)
+    outputString = repeat(" ", maxStringLength + 2)
+    actualLength = Ref{Int32}(maxStringLength)
+    val = Ref{Float64}(0.0)
     Lib.helicsDataBufferToNamedPoint(data, outputString, maxStringLength, actualLength, val)
     return outputString[1:actualLength[]-1], val[]
 end
@@ -1058,7 +1058,7 @@ Set a handle option on an [`Endpoint`](@ref)
 - `option`: Integer code for the option to set [`HelicsHandleOptions`](@ref)
 - `value`: The value to set the option
 """
-function helicsEndpointSetOption(endpoint::Endpoint, option::Union{Int, HELICS.HelicsHandleOptions}, value::Bool)
+function helicsEndpointSetOption(endpoint::Endpoint, option::Union{Int,HELICS.HelicsHandleOptions}, value::Bool)
     @invoke_and_check Lib.helicsEndpointSetOption(endpoint, option, value ? 1 : 0)
 end
 
@@ -1068,7 +1068,7 @@ Get a handle option on an [`Endpoint`](@ref)
 - `endpoint`: The [`Endpoint`](@ref) to modify
 - `option`: Integer code for the option to set [`HelicsHandleOptions`](@ref)
 """
-function helicsEndpointGetOption(endpoint::Endpoint, option::Union{Int, HELICS.HelicsHandleOptions})::Bool
+function helicsEndpointGetOption(endpoint::Endpoint, option::Union{Int,HELICS.HelicsHandleOptions})::Bool
     return Lib.helicsEndpointGetOption(endpoint, option) == 1 ? true : false
 end
 
@@ -1138,7 +1138,7 @@ a few extra features of name matching to function on the [`Federate`](@ref) inte
 
 - a [`Filter`](@ref) object
 """
-function helicsFederateRegisterFilter(fed::Federate, kind::Union{Int, HELICS.HelicsFilterTypes}, name::String)::Filter
+function helicsFederateRegisterFilter(fed::Federate, kind::Union{Int,HELICS.HelicsFilterTypes}, name::String)::Filter
     return @invoke_and_check Lib.helicsFederateRegisterFilter(fed, kind, name)
 end
 
@@ -1158,7 +1158,7 @@ a few extra features of name matching to function on the [`Federate`](@ref) inte
 
 - a [`Filter`](@ref) object
 """
-function helicsFederateRegisterGlobalFilter(fed::Federate, kind::Union{Int, HELICS.HelicsFilterTypes}, name::String)::Filter
+function helicsFederateRegisterGlobalFilter(fed::Federate, kind::Union{Int,HELICS.HelicsFilterTypes}, name::String)::Filter
     return @invoke_and_check Lib.helicsFederateRegisterGlobalFilter(fed, kind, name)
 end
 
@@ -1216,7 +1216,7 @@ a few extra features of name matching to function on the [`Federate`](@ref) inte
 
 - a [`Filter`](@ref) object
 """
-function helicsCoreRegisterFilter(core::Core, kind::Union{Int, HELICS.HelicsFilterTypes}, name::String)::Filter
+function helicsCoreRegisterFilter(core::Core, kind::Union{Int,HELICS.HelicsFilterTypes}, name::String)::Filter
     return @invoke_and_check Lib.helicsCoreRegisterFilter(core, kind, name)
 end
 
@@ -1812,7 +1812,7 @@ functions for subscriptions and publications
 
 - the [`Publication`](@ref)
 """
-function helicsFederateRegisterPublication(fed::Federate, key::String, kind::Union{Int, HELICS.HelicsDataTypes}, units::String="")::Publication
+function helicsFederateRegisterPublication(fed::Federate, key::String, kind::Union{Int,HELICS.HelicsDataTypes}, units::String="")::Publication
     return @invoke_and_check Lib.helicsFederateRegisterPublication(fed, key, kind, units)
 end
 
@@ -1856,7 +1856,7 @@ functions for subscriptions and publications
 
 - the [`Publication`](@ref)
 """
-function helicsFederateRegisterGlobalPublication(fed::Federate, key::String, kind::Union{Int, HELICS.HelicsDataTypes}, units::String="")::Publication
+function helicsFederateRegisterGlobalPublication(fed::Federate, key::String, kind::Union{Int,HELICS.HelicsDataTypes}, units::String="")::Publication
     return @invoke_and_check Lib.helicsFederateRegisterGlobalPublication(fed, key, kind, units)
 end
 
@@ -1898,7 +1898,7 @@ functions for subscriptions, inputs, and publications
 
 - the [`Input`](@ref)
 """
-function helicsFederateRegisterInput(fed::Federate, key::String, kind::Union{Int, HELICS.HelicsDataTypes}, units::String="")::Input
+function helicsFederateRegisterInput(fed::Federate, key::String, kind::Union{Int,HELICS.HelicsDataTypes}, units::String="")::Input
     return @invoke_and_check Lib.helicsFederateRegisterInput(fed, key, kind, units)
 end
 
@@ -1940,7 +1940,7 @@ functions for subscriptions and publications
 
 - the [`Publication`](@ref)
 """
-function helicsFederateRegisterGlobalInput(fed::Federate, key::String, kind::Union{Int, HELICS.HelicsDataTypes}, units::String="")::Input
+function helicsFederateRegisterGlobalInput(fed::Federate, key::String, kind::Union{Int,HELICS.HelicsDataTypes}, units::String="")::Input
     return @invoke_and_check Lib.helicsFederateRegisterGlobalInput(fed, key, kind, units)
 end
 
@@ -2185,11 +2185,11 @@ Publish a vector of complex doubles
 """
 function helicsPublicationPublishComplexVector(pub::Publication, vectorInput::Vector{ComplexF64})
     vectorLength = length(vectorInput)
-	doubleVectorInput = Vector{Float64}(undef,0)
-	for cVal in vectorInput
-		push!(doubleVectorInput, cVal.re)
-		push!(doubleVectorInput, cVal.im)
-	end
+    doubleVectorInput = Vector{Float64}(undef, 0)
+    for cVal in vectorInput
+        push!(doubleVectorInput, cVal.re)
+        push!(doubleVectorInput, cVal.im)
+    end
     @invoke_and_check Lib.helicsPublicationPublishComplexVector(pub, doubleVectorInput, length(doubleVectorInput))
 end
 
@@ -2426,11 +2426,11 @@ function helicsInputGetComplexVector(ipt::Input)::Vector{Float64}
     data = Vector{Float64}(undef, maxlen)
     actualSize = Ref(maxlen)
     @invoke_and_check Lib.helicsInputGetComplexVector(ipt, data, maxlen, actualSize)
-	complexVector = Vector{ComplexF64}(undef,0)
-	for i in 1:actualSize[]/2
-		push!(complexVector, data[2*i - 1] + im * data[2*i])
-	end
-    return compelxVector
+    complexVector = Vector{ComplexF64}(undef, 0)
+    for i in 1:actualSize[]/2
+        push!(complexVector, data[2*i-1] + im * data[2*i])
+    end
+    return complexVector
 end
 
 """
@@ -2445,7 +2445,7 @@ Get a named point from a [`Subscription`](@ref)
 - outputString storage for copying a null terminated string
 - val the double value for the named point
 """
-function helicsInputGetNamedPoint(ipt::Input)::Tuple{String, Float64}
+function helicsInputGetNamedPoint(ipt::Input)::Tuple{String,Float64}
     maxStringLen = helicsInputGetStringSize(ipt)
     outputString = repeat(" ", maxStringLen + 2)
     actualLength = Ref{Int32}(maxStringLen)
@@ -2574,11 +2574,11 @@ Set the default as a vector of complex doubles
 """
 function helicsInputSetDefaultComplexVector(ipt::Input, vectorInput::Vector{ComplexF64})
     vectorLength = length(vectorInput)
-	doublesVector = Vector{Float64}(undef,0)
-	for cVal in vectorInput
-		push!(doublesVector, cVal.re)
-		push!(doublesVector, cVal.im)
-	end
+    doublesVector = Vector{Float64}(undef, 0)
+    for cVal in vectorInput
+        push!(doublesVector, cVal.re)
+        push!(doublesVector, cVal.im)
+    end
     @invoke_and_check Lib.helicsInputSetDefaultComplexVector(ipt, doublesVector, length(doublesVector))
 end
 
@@ -3582,7 +3582,7 @@ this will create a new [`Federate`](@ref) object that references the existing fe
 
 - a new reference to the same federate
 """
-function helicsFederateClone(fed::T)::T where T <: Federate
+function helicsFederateClone(fed::T)::T where {T<:Federate}
     return @invoke_and_check Lib.helicsFederateClone(fed)
 end
 
@@ -3729,7 +3729,7 @@ valid values available by definitions in api-data.h
 - `fi`: the [`FederateInfo`](@ref) object to alter
 - `coretype`: an numerical code for a core type see /ref HelicsCoreTypes
 """
-function helicsFederateInfoSetCoreType(fi::FederateInfo, coretype::Union{Int, HELICS.HelicsCoreTypes})
+function helicsFederateInfoSetCoreType(fi::FederateInfo, coretype::Union{Int,HELICS.HelicsCoreTypes})
     @invoke_and_check Lib.helicsFederateInfoSetCoreType(fi, coretype)
 end
 
@@ -3828,7 +3828,7 @@ valid flags are available [`HelicsFederateFlags`](@ref)
 - `flag`: a numerical index for a flag
 - `value`: the desired value of the flag `true` or `false`
 """
-function helicsFederateInfoSetFlagOption(fi::FederateInfo, flag::Union{Int, HELICS.HelicsFederateFlags}, value::Bool)
+function helicsFederateInfoSetFlagOption(fi::FederateInfo, flag::Union{Int,HELICS.HelicsFederateFlags}, value::Bool)
     @invoke_and_check Lib.helicsFederateInfoSetFlagOption(fi, flag, value ? 1 : 0)
 end
 
@@ -3848,13 +3848,13 @@ end
 
 """
 """
-function helicsFederateInfoSetTimeProperty(fi::FederateInfo, timeProperty::Union{Int, HELICS.HelicsProperties}, propertyValue::HELICS.HELICS_TIME)
+function helicsFederateInfoSetTimeProperty(fi::FederateInfo, timeProperty::Union{Int,HELICS.HelicsProperties}, propertyValue::HELICS.HELICS_TIME)
     @invoke_and_check Lib.helicsFederateInfoSetTimeProperty(fi, timeProperty, propertyValue)
 end
 
 """
 """
-function helicsFederateInfoSetIntegerProperty(fi::FederateInfo, intProperty::Union{Int, HELICS.HelicsProperties}, propertyValue::Int)
+function helicsFederateInfoSetIntegerProperty(fi::FederateInfo, intProperty::Union{Int,HELICS.HelicsProperties}, propertyValue::Int)
     @invoke_and_check Lib.helicsFederateInfoSetIntegerProperty(fi, intProperty, propertyValue)
 end
 
@@ -4071,7 +4071,7 @@ this call allows for finer grain control of the iterative process then [`helicsF
 
 - an iteration structure with field containing the time and iteration status
 """
-function helicsFederateEnterExecutingModeIterative(fed::Federate, iterate::Union{Int, HELICS.HelicsIterationRequest})::HELICS.HelicsIterationResult
+function helicsFederateEnterExecutingModeIterative(fed::Federate, iterate::Union{Int,HELICS.HelicsIterationRequest})::HELICS.HelicsIterationResult
     return @invoke_and_check Lib.helicsFederateEnterExecutingModeIterative(fed, iterate)
 end
 
@@ -4085,7 +4085,7 @@ This call allows for finer grain control of the iterative process then [`helicsF
 - `fed`: the [`Federate`](@ref) to make the request of
 - `iterate`: the requested iteration mode
 """
-function helicsFederateEnterExecutingModeIterativeAsync(fed::Federate, iterate::Union{Int, HELICS.HelicsIterationRequest})
+function helicsFederateEnterExecutingModeIterativeAsync(fed::Federate, iterate::Union{Int,HELICS.HelicsIterationRequest})
     return @invoke_and_check Lib.helicsFederateEnterExecutingModeIterativeAsync(fed, iterate)
 end
 
@@ -4184,7 +4184,7 @@ this call allows for finer grain control of the iterative process then [`helicsF
 - the granted time
 - the iteration specification of the result
 """
-function helicsFederateRequestTimeIterative(fed::Federate, requestTime::HELICS.HELICS_TIME, iterate::Union{Int, HELICS.HelicsIterationRequest})::Tuple{Float64, HELICS.HelicsIterationResult}
+function helicsFederateRequestTimeIterative(fed::Federate, requestTime::HELICS.HELICS_TIME, iterate::Union{Int,HELICS.HelicsIterationRequest})::Tuple{Float64,HELICS.HelicsIterationResult}
     outIteration = Ref(HELICS.HelicsIterationResult(0))
     t = @invoke_and_check Lib.helicsFederateRequestTimeIterative(fed, requestTime, iterate, outIteration)
     return t, outIteration[]
@@ -4233,7 +4233,7 @@ this call allows for finer grain control of the iterative process then [`helicsF
 
 - a void object with a return code of the result
 """
-function helicsFederateRequestTimeIterativeAsync(fed::Federate, requestTime::HELICS.HELICS_TIME, iterate::Union{Int, HELICS.HelicsIterationRequest})
+function helicsFederateRequestTimeIterativeAsync(fed::Federate, requestTime::HELICS.HELICS_TIME, iterate::Union{Int,HELICS.HelicsIterationRequest})
     @invoke_and_check Lib.helicsFederateRequestTimeIterativeAsync(fed, requestTime, iterate)
 end
 
@@ -4249,7 +4249,7 @@ Complete an iterative time request asynchronous call
 - the granted time
 - `outIterate`  the iteration specification of the result
 """
-function helicsFederateRequestTimeIterativeComplete(fed::Federate)::Tuple{Float64, HELICS.HelicsIterationResult}
+function helicsFederateRequestTimeIterativeComplete(fed::Federate)::Tuple{Float64,HELICS.HelicsIterationResult}
     outIterate = Ref(HELICS.HelicsIterationResult(0))
     t = @invoke_and_check Lib.helicsFederateRequestTimeIterativeComplete(fed, outIterate)
     return t, outIterate[]
@@ -4291,7 +4291,7 @@ Set a time based property for a [`Federate`](@ref)
 - `timeProperty`: a integer code for a time property
 - `time`: the requested value of the property
 """
-function helicsFederateSetTimeProperty(fed::Federate, timeProperty::Union{Int, HELICS.HelicsProperties}, time::HELICS.HELICS_TIME)
+function helicsFederateSetTimeProperty(fed::Federate, timeProperty::Union{Int,HELICS.HelicsProperties}, time::HELICS.HELICS_TIME)
     @invoke_and_check Lib.helicsFederateSetTimeProperty(fed, timeProperty, time)
 end
 
@@ -4304,7 +4304,7 @@ Set a flag for the [`Federate`](@ref)
 - `flag`: the flag to change
 - `flagValue`: the new value of the flag 0 for false !=0 for true
 """
-function helicsFederateSetFlagOption(fed::Federate, flag::Union{Int, HELICS.HelicsFederateFlags, HELICS.HelicsHandleOptions}, flagValue::Bool)
+function helicsFederateSetFlagOption(fed::Federate, flag::Union{Int,HELICS.HelicsFederateFlags,HELICS.HelicsHandleOptions}, flagValue::Bool)
     @invoke_and_check Lib.helicsFederateSetFlagOption(fed, flag, flagValue ? 1 : 0)
 end
 
@@ -4331,7 +4331,7 @@ Set an integer based property of a [`Federate`](@ref)
 - `intProperty`: the property to set
 - `propertyVal`: the value of the property
 """
-function helicsFederateSetIntegerProperty(fed::Federate, intProperty::Union{Int, HELICS.HelicsProperties}, propertyVal::Int)
+function helicsFederateSetIntegerProperty(fed::Federate, intProperty::Union{Int,HELICS.HelicsProperties}, propertyVal::Int)
     @invoke_and_check Lib.helicsFederateSetIntegerProperty(fed, intProperty, propertyVal)
 end
 
@@ -4343,7 +4343,7 @@ Get the current value of a time based property in a [`Federate`](@ref)
 - `fed`: the [`Federate`](@ref) query
 - `timeProperty`: the property to query
 """
-function helicsFederateGetTimeProperty(fed::Federate, timeProperty::Union{Int, HELICS.HelicsProperties})::Float64
+function helicsFederateGetTimeProperty(fed::Federate, timeProperty::Union{Int,HELICS.HelicsProperties})::Float64
     return @invoke_and_check Lib.helicsFederateGetTimeProperty(fed, timeProperty)
 end
 
@@ -4359,7 +4359,7 @@ Get a flag value for a [`Federate`](@ref)
 
 - the value of the flag
 """
-function helicsFederateGetFlagOption(fed::Federate, flag::Union{Int, HELICS.HelicsFederateFlags, HELICS.HelicsHandleOptions})::Bool
+function helicsFederateGetFlagOption(fed::Federate, flag::Union{Int,HELICS.HelicsFederateFlags,HELICS.HelicsHandleOptions})::Bool
     r = @invoke_and_check Lib.helicsFederateGetFlagOption(fed, flag)
     return r == 1 ? true : false
 end
@@ -4378,7 +4378,7 @@ debug and trace only do anything if they were enabled in the compilation
 
 - the value of the property
 """
-function helicsFederateGetIntegerProperty(fed::Federate, intProperty::Union{Int, HELICS.HelicsProperties, HELICS.HelicsHandleOptions})::Int
+function helicsFederateGetIntegerProperty(fed::Federate, intProperty::Union{Int,HELICS.HelicsProperties,HELICS.HelicsHandleOptions})::Int
     return @invoke_and_check Lib.helicsFederateGetIntegerProperty(fed, intProperty)
 end
 
@@ -5010,7 +5010,7 @@ Set a flag on a message
 - `flag`: An index of a flag to set on the message
 - `flagValue`: The desired value of the flag
 """
-function helicsMessageSetFlagOption(message::Message, flag::Union{Int, HelicsFederateFlags}, flagValue::Bool)
+function helicsMessageSetFlagOption(message::Message, flag::Union{Int,HelicsFederateFlags}, flagValue::Bool)
     @invoke_and_check Lib.helicsMessageSetFlagOption(message, flag, flagValue)
 end
 
@@ -5141,7 +5141,7 @@ Clear any time barrier on a broker.
 - `broker`: the [`Broker`](@ref) to clear the time barrier for
 """
 function helicsBrokerClearTimeBarrier(broker::Broker)
-	Lib.helicsBrokerClearTimeBarrier(broker)
+    Lib.helicsBrokerClearTimeBarrier(broker)
 end
 
 """
@@ -5241,7 +5241,7 @@ Log a message through a [`Federate`](@ref)
 - `loglevel`: The level of the message to log. See [`HelicsLogLevels`](@ref)
 - `logmessage`: The message to put in the log
 """
-function helicsFederateLogLevelMessage(fed::Federate, loglevel::Union{Int, HelicsLogLevels}, logmessage::String)
+function helicsFederateLogLevelMessage(fed::Federate, loglevel::Union{Int,HelicsLogLevels}, logmessage::String)
     @invoke_and_check Lib.helicsFederateLogLevelMessage(fed, loglevel, logmessage)
 end
 
@@ -5588,7 +5588,7 @@ to specific queries with answers specific to a federate.
 - `queryResult`: A callback with signature HelicsIterationRequest(void *userdata)
 """
 function helicsQueryBufferFill(buffer::QueryBuffer, queryResult::String)
-	strSize = CInt(length(queryResult))
+    strSize = CInt(length(queryResult))
     @invoke_and_check Lib.helicsQueryBufferFill(buffer, queryResult, strSize)
 end
 

--- a/src/api.jl
+++ b/src/api.jl
@@ -2421,7 +2421,7 @@ Get a complex vector from a [`Subscription`](@ref)
 
 - `ipt`: the [`Input`](@ref) to get the result for
 """
-function helicsInputGetComplexVector(ipt::Input)::Vector{Float64}
+function helicsInputGetComplexVector(ipt::Input)::Vector{ComplexF64}
     maxlen = Cint(helicsInputGetVectorSize(ipt))
     data = Vector{Float64}(undef, maxlen)
     actualSize = Ref(maxlen)

--- a/src/api.jl
+++ b/src/api.jl
@@ -2427,7 +2427,7 @@ function helicsInputGetComplexVector(ipt::Input)::Vector{Float64}
     actualSize = Ref(maxlen)
     @invoke_and_check Lib.helicsInputGetComplexVector(ipt, data, maxlen, actualSize)
     complexVector = Vector{ComplexF64}(undef, 0)
-    for i in 1:actualSize[]/2
+    for i in 1:Int(actualSize[] / 2)
         push!(complexVector, data[2*i-1] + im * data[2*i])
     end
     return complexVector

--- a/test/api.jl
+++ b/test/api.jl
@@ -257,9 +257,9 @@ end
     fed1State = h.helicsFederateGetState(fed1)
     @test fed1State == 2
     fed1PubCount = h.helicsFederateGetPublicationCount(fed1)
-    @test fed1PubCount == 7
+    @test fed1PubCount == 8
     fed1SubCount = h.helicsFederateGetInputCount(fed1)
-    @test fed1SubCount == 7
+    @test fed1SubCount == 8
 
     h.helicsPublicationPublishBoolean(pub5, true)
     h.helicsPublicationPublishComplex(pub2, 5.6 + im * -0.67)
@@ -270,7 +270,7 @@ end
     pub6Vector = [4.5, 56.5]
     h.helicsPublicationPublishVector(pub6, pub6Vector)
     pub8Vector = [4.5 + im * -0.67, 56.5 + im * 0.0]
-    h.helicsPublicationPublishVector(pub8, pub8Vector)
+    h.helicsPublicationPublishComplexVector(pub8, pub8Vector)
     sleep(0.500)
     h.helicsFederateRequestTimeAsync(fed1, 1.0)
 
@@ -322,7 +322,7 @@ end
 
     @test h.helicsInputGetVector(sub6) == pub6Vector
 
-    @test h.helicsInputGetVector(sub8) == pub8Vector
+    @test h.helicsInputGetComplexVector(sub8) == pub8Vector
 
     h.helicsFederateDisconnect(fed1)
     #    h.helicsFederateDisconnect(fed2)

--- a/test/api.jl
+++ b/test/api.jl
@@ -67,8 +67,8 @@ end
     h.helicsFederateInfoSetIntegerProperty(fi, h.HELICS_PROPERTY_INT_LOG_LEVEL, 6)
 
     fed = h.helicsCreateValueFederate("test1", fi)
-	fedLogLevel = h.helicsFederateGetIntegerProperty(fed, h.HELICS_PROPERTY_INT_LOG_LEVEL)
-	@test fedLogLevel == 6
+    fedLogLevel = h.helicsFederateGetIntegerProperty(fed, h.HELICS_PROPERTY_INT_LOG_LEVEL)
+    @test fedLogLevel == 6
     userdata = UserData(5)
 
     h.helicsFederateSetLoggingCallback(fed, @cfunction(logger, Cvoid, (Cint, Cstring, Cstring, Ptr{Cvoid})), Ref(userdata))
@@ -106,19 +106,19 @@ end
     h.helicsFederateInfoSetCoreTypeFromString(fedInfo1, "zmq")
     h.helicsFederateInfoSetFlagOption(fedInfo1, 1, true)
     h.helicsFederateInfoSetTimeProperty(fedInfo1,
-            h.HELICS_PROPERTY_TIME_INPUT_DELAY, 1.0)
+        h.HELICS_PROPERTY_TIME_INPUT_DELAY, 1.0)
     h.helicsFederateInfoSetIntegerProperty(fedInfo1,
-            h.HELICS_PROPERTY_INT_LOG_LEVEL, 1)
+        h.HELICS_PROPERTY_INT_LOG_LEVEL, 1)
     h.helicsFederateInfoSetIntegerProperty(fedInfo1,
-            h.HELICS_PROPERTY_INT_MAX_ITERATIONS, 100)
+        h.HELICS_PROPERTY_INT_MAX_ITERATIONS, 100)
     h.helicsFederateInfoSetTimeProperty(fedInfo1,
-            h.HELICS_PROPERTY_TIME_OUTPUT_DELAY, 1.0)
+        h.HELICS_PROPERTY_TIME_OUTPUT_DELAY, 1.0)
     h.helicsFederateInfoSetTimeProperty(fedInfo1,
-            h.HELICS_PROPERTY_TIME_PERIOD, 1.0)
+        h.HELICS_PROPERTY_TIME_PERIOD, 1.0)
     h.helicsFederateInfoSetTimeProperty(fedInfo1,
-            h.HELICS_PROPERTY_TIME_DELTA, 1.0)
+        h.HELICS_PROPERTY_TIME_DELTA, 1.0)
     h.helicsFederateInfoSetTimeProperty(fedInfo1,
-            h.HELICS_PROPERTY_TIME_OFFSET, 0.1)
+        h.HELICS_PROPERTY_TIME_OFFSET, 0.1)
     h.helicsFederateInfoFree(fedInfo1)
 
     broker3 = h.helicsCreateBroker("zmq", "broker3", "--federates 1 --loglevel ERROR")
@@ -129,21 +129,21 @@ end
     h.helicsFederateInfoSetIntegerProperty(fedInfo2, h.HELICS_PROPERTY_INT_LOG_LEVEL, 1)
     h.helicsFederateInfoSetTimeProperty(fedInfo2, h.HELICS_PROPERTY_TIME_DELTA, 1.0)
     fed1 = h.helicsCreateCombinationFederate("fed1", fedInfo2)
-#    fed2 = h.helicsFederateClone(fed1)
-#    fed3 = h.helicsGetFederateByName("fed1")
-#    h.helicsFederateSetFlagOption(fed2, 1, false)
+    #    fed2 = h.helicsFederateClone(fed1)
+    #    fed3 = h.helicsGetFederateByName("fed1")
+    #    h.helicsFederateSetFlagOption(fed2, 1, false)
 
     h.helicsFederateSetTimeProperty(fed1, h.HELICS_PROPERTY_TIME_INPUT_DELAY, 0.0)
-	h.helicsFederateSetTimeProperty(fed1, h.HELICS_PROPERTY_TIME_OFFSET, 0.0)
+    h.helicsFederateSetTimeProperty(fed1, h.HELICS_PROPERTY_TIME_OFFSET, 0.0)
     h.helicsFederateSetIntegerProperty(fed1, h.HELICS_PROPERTY_INT_LOG_LEVEL, 1)
     h.helicsFederateSetIntegerProperty(fed1, h.HELICS_PROPERTY_INT_MAX_ITERATIONS, 100)
     h.helicsFederateSetTimeProperty(fed1, h.HELICS_PROPERTY_TIME_OUTPUT_DELAY, 0.0)
     h.helicsFederateSetTimeProperty(fed1, h.HELICS_PROPERTY_TIME_PERIOD, 0.0)
     h.helicsFederateSetTimeProperty(fed1, h.HELICS_PROPERTY_TIME_DELTA, 1.0)
 
-#    fed2CloningFilter = h.helicsFederateRegisterCloningFilter(fed2, "fed2/Ep1")
-#    fed2DestinationFilter = h.helicsFederateRegisterFilter(fed2, h.HELICS_FILTER_TYPE_DELAY, "fed2DestinationFilter")
-#    h.helicsFilterAddDestinationTarget(fed2DestinationFilter, "ep2")
+    #    fed2CloningFilter = h.helicsFederateRegisterCloningFilter(fed2, "fed2/Ep1")
+    #    fed2DestinationFilter = h.helicsFederateRegisterFilter(fed2, h.HELICS_FILTER_TYPE_DELAY, "fed2DestinationFilter")
+    #    h.helicsFilterAddDestinationTarget(fed2DestinationFilter, "ep2")
 
     ep1 = h.helicsFederateRegisterEndpoint(fed1, "Ep1", "string")
     ep2 = h.helicsFederateRegisterGlobalEndpoint(fed1, "Ep2", "string")
@@ -152,7 +152,7 @@ end
 
     sub1 = h.helicsFederateRegisterSubscription(fed1, "pub1")
     sub2 = h.helicsFederateRegisterSubscription(fed1, "pub2")
-#    h.helicsInputAddTarget(sub2, "Ep2")
+    #    h.helicsInputAddTarget(sub2, "Ep2")
     pub3 = h.helicsFederateRegisterPublication(fed1, "pub3", h.HELICS_DATA_TYPE_STRING, "")
 
     pub1KeyString = h.helicsPublicationGetName(pub1)
@@ -166,16 +166,16 @@ end
     @test "pub1" == sub1KeyString
     @test "" == sub1UnitsString
 
-#    fed2SourceFilter = h.helicsFederateRegisterFilter(fed2,
-#            h.HELICS_FILTER_TYPE_DELAY, "fed2SourceFilter")
-#    h.helicsFilterAddSourceTarget(fed2SourceFilter, "Ep2")
-#    h.helicsFilterAddDestinationTarget(fed2SourceFilter, "fed2/Ep1")
-#    h.helicsFilterRemoveTarget(fed2SourceFilter, "fed2/Ep1")
-#    h.helicsFilterAddSourceTarget(fed2SourceFilter, "Ep2")
-#    h.helicsFilterRemoveTarget(fed2SourceFilter, "Ep2")
+    #    fed2SourceFilter = h.helicsFederateRegisterFilter(fed2,
+    #            h.HELICS_FILTER_TYPE_DELAY, "fed2SourceFilter")
+    #    h.helicsFilterAddSourceTarget(fed2SourceFilter, "Ep2")
+    #    h.helicsFilterAddDestinationTarget(fed2SourceFilter, "fed2/Ep1")
+    #    h.helicsFilterRemoveTarget(fed2SourceFilter, "fed2/Ep1")
+    #    h.helicsFilterAddSourceTarget(fed2SourceFilter, "Ep2")
+    #    h.helicsFilterRemoveTarget(fed2SourceFilter, "Ep2")
 
-#    fed2SourceFilterNameString = h.helicsFilterGetName(fed2SourceFilter)
-#    @test fed2SourceFilterNameString == "fed1/fed2SourceFilter"
+    #    fed2SourceFilterNameString = h.helicsFilterGetName(fed2SourceFilter)
+    #    @test fed2SourceFilterNameString == "fed1/fed2SourceFilter"
 
     sub3 = h.helicsFederateRegisterSubscription(fed1, "fed1/pub3", "")
     pub4 = h.helicsFederateRegisterTypePublication(fed1, "pub4", "int", "")
@@ -187,25 +187,30 @@ end
     pub6 = h.helicsFederateRegisterGlobalPublication(fed1, "pub6", h.HELICS_DATA_TYPE_VECTOR, "")
     sub6 = h.helicsFederateRegisterSubscription(fed1, "pub6", "")
     pub7 = h.helicsFederateRegisterGlobalPublication(fed1, "pub7",
-            h.HELICS_DATA_TYPE_NAMED_POINT, "")
+        h.HELICS_DATA_TYPE_NAMED_POINT, "")
     sub7 = h.helicsFederateRegisterSubscription(fed1, "pub7", "")
+    pub8 = h.helicsFederateRegisterGlobalPublication(fed1, "pub8", h.HELICS_DATA_TYPE_COMPLEX_VECTOR, "")
+    sub8 = h.helicsFederateRegisterSubscription(fed1, "pub8", "")
 
-    h.helicsInputSetDefaultBoolean(sub5, false)
-    h.helicsInputSetDefaultComplex(sub2, -9.9 + im * 2.5)
     h.helicsInputSetDefaultDouble(sub1, 3.4)
-    h.helicsInputSetDefaultInteger(sub4, 6)
-    h.helicsInputSetDefaultNamedPoint(sub7, "hollow", 20.0)
+    h.helicsInputSetDefaultComplex(sub2, -9.9 + im * 2.5)
     h.helicsInputSetDefaultString(sub3, "default")
-    sub6Default = [ 3.4, 90.9, 4.5 ]
+    h.helicsInputSetDefaultInteger(sub4, 6)
+    h.helicsInputSetDefaultBoolean(sub5, false)
+    sub6Default = [3.4, 90.9, 4.5]
     h.helicsInputSetDefaultVector(sub6, sub6Default)
-#    h.helicsEndpointSubscribe(ep2, "fed1/pub3")
+    h.helicsInputSetDefaultNamedPoint(sub7, "hollow", 20.0)
+    sub8Default = [3.4 + im * 2.5, 90.9 + im * 0.0, 4.5 + im * 0.0]
+    h.helicsInputSetDefaultComplexVector(sub8, sub8Default)
+
+    #    h.helicsEndpointSubscribe(ep2, "fed1/pub3")
     h.helicsFederateEnterInitializingModeAsync(fed1)
     rs = h.helicsFederateIsAsyncOperationCompleted(fed1)
     if (rs == 0)
         sleep(0.500)
         rs = h.helicsFederateIsAsyncOperationCompleted(fed1)
         if (rs == 0)
-            sleep(.500)
+            sleep(0.500)
             rs = h.helicsFederateIsAsyncOperationCompleted(fed1)
             if (rs == 0)
                 @test true == false
@@ -262,8 +267,10 @@ end
     h.helicsPublicationPublishInteger(pub4, 1)
     h.helicsPublicationPublishNamedPoint(pub7, "Blah Blah", 20.0)
     h.helicsPublicationPublishString(pub3, "Mayhem")
-    pub6Vector = [ 4.5, 56.5 ]
+    pub6Vector = [4.5, 56.5]
     h.helicsPublicationPublishVector(pub6, pub6Vector)
+    pub8Vector = [4.5 + im * -0.67, 56.5 + im * 0.0]
+    h.helicsPublicationPublishVector(pub8, pub8Vector)
     sleep(0.500)
     h.helicsFederateRequestTimeAsync(fed1, 1.0)
 
@@ -313,13 +320,15 @@ end
     sub3ValueSize = h.helicsInputGetStringSize(sub3)
     @test sub3ValueSize == 7
 
-    @test h.helicsInputGetVector(sub6) == [4.5, 56.5]
+    @test h.helicsInputGetVector(sub6) == pub6Vector
+
+    @test h.helicsInputGetVector(sub8) == pub8Vector
 
     h.helicsFederateDisconnect(fed1)
-#    h.helicsFederateDisconnect(fed2)
+    #    h.helicsFederateDisconnect(fed2)
     h.helicsFederateFree(fed1)
-#    h.helicsFederateDisconnect(fed2)
-#    h.helicsFederateFree(fed2)
+    #    h.helicsFederateDisconnect(fed2)
+    #    h.helicsFederateFree(fed2)
     h.helicsFederateInfoFree(fedInfo2)
     h.helicsBrokerDisconnect(broker3)
 

--- a/test/badinputs.jl
+++ b/test/badinputs.jl
@@ -13,7 +13,7 @@ include("init.jl")
     @test_throws ErrorException h.helicsEndpointGetMessage(ept1)
 
     @test_throws ErrorException h.helicsFederateGetMessage(mFed1)
-	mess0 = h.helicsEndpointCreateMessage(ept1)
+    mess0 = h.helicsEndpointCreateMessage(ept1)
     h.helicsFederateDisconnect(mFed1)
     @test_throws h.Utils.HELICS_ERROR_INVALID_FUNCTION_CALL h.helicsEndpointSendMessage(ept1, mess0)
 
@@ -75,7 +75,7 @@ end
 
     @test_throws h.Utils.HELICS_ERROR_INVALID_ARGUMENT h.helicsFederateRegisterFromPublicationJSON(vFed1, "unknownfile.json")
 
-    @test_throws h.Utils.HELICS_ERROR_EXTERNAL_TYPE h.helicsFederateRegisterInterfaces(vFed1, "unknownfile.json")
+    @test_throws h.Utils.HELICS_ERROR_INVALID_ARGUMENT h.helicsFederateRegisterInterfaces(vFed1, "unknownfile.json")
 
     subid = h.helicsFederateRegisterTypeInput(vFed1, "inp1", "string", "")
     @test_throws h.Utils.HELICS_ERROR_REGISTRATION_FAILURE subid2 = h.helicsFederateRegisterTypeInput(vFed1, "inp1", "string", "")
@@ -385,21 +385,21 @@ end
     h.helicsFederateInfoSetSeparator(fedinfo, '-')
     h.helicsFederateSetSeparator(vFed1, '-')
 
-    h.helicsFederateRegisterGlobalTypePublication(vFed1, "pub1", "custom1", "");
+    h.helicsFederateRegisterGlobalTypePublication(vFed1, "pub1", "custom1", "")
 
-    subid = h.helicsFederateRegisterTypeInput(vFed1, "inp1", "custom2", "");
+    subid = h.helicsFederateRegisterTypeInput(vFed1, "inp1", "custom2", "")
 
-    h.helicsInputAddTarget(subid, "pub1");
+    h.helicsInputAddTarget(subid, "pub1")
 
-    h.helicsFederateSetTimeProperty(vFed1, h.HELICS_PROPERTY_TIME_PERIOD, 1.0);
+    h.helicsFederateSetTimeProperty(vFed1, h.HELICS_PROPERTY_TIME_PERIOD, 1.0)
 
-    @test_throws h.Utils.HELICS_ERROR_CONNECTION_FAILURE resIt = h.helicsFederateEnterExecutingModeIterative(vFed1, h.HELICS_ITERATION_REQUEST_NO_ITERATION);
+    @test_throws h.Utils.HELICS_ERROR_CONNECTION_FAILURE resIt = h.helicsFederateEnterExecutingModeIterative(vFed1, h.HELICS_ITERATION_REQUEST_NO_ITERATION)
 
-    @test_throws h.Utils.HELICS_ERROR_INVALID_FUNCTION_CALL h.helicsFederateRequestTimeIterativeAsync(vFed1, 1.0, h.HELICS_ITERATION_REQUEST_NO_ITERATION);
+    @test_throws h.Utils.HELICS_ERROR_INVALID_FUNCTION_CALL h.helicsFederateRequestTimeIterativeAsync(vFed1, 1.0, h.HELICS_ITERATION_REQUEST_NO_ITERATION)
 
     @test_throws h.Utils.HELICS_ERROR_INVALID_FUNCTION_CALL res = h.helicsFederateRequestTimeIterativeComplete(vFed1)
 
-    h.helicsFederateDisconnect(vFed1);
+    h.helicsFederateDisconnect(vFed1)
 
     destroyFederate(vFed1, fedinfo)
 


### PR DESCRIPTION
I updated the Manifest.toml, since it was testing against HELICS 2.7. We should probably remove the Manifest.toml since most Julia libraries do not have one and instead use better version dependencies like in #30.

Fixes #32.

I also discovered a couple other bugs in that function. One bug involved trying to iterate from 1 to a floating point number, which fails. Another bug involved it casting to a Vector{Float64}.

I may have run a mild formatter on a couple files, which should only change whitespace from what I saw.